### PR TITLE
docs: fix typo in the Ticker.md

### DIFF
--- a/docs/docs/components/Ticker.md
+++ b/docs/docs/components/Ticker.md
@@ -25,7 +25,7 @@ import { Ticker } from "react-ts-tradingview-widgets";
 | ColorTheme   | light / dark                           |
 | TickerSymbol | [_**TickerSymbol[]**_](#ticker-symbol) |
 
-## Ticker roperties
+## Ticker properties
 
 | Property      | Type                                   | Required | Default                    | Description                          |
 | ------------- | -------------------------------------- | -------- | -------------------------- | ------------------------------------ |


### PR DESCRIPTION
Fixed a typo:  
- In `Ticker.md`, corrected `roperties` to `properties`.  
