### PR TITLE
fix: correct spelling of backgroundColor in SymbolOverview component

### DIFF
--- a/docs/docs/components/SymbolOverview.md
+++ b/docs/docs/components/SymbolOverview.md
@@ -74,7 +74,7 @@ import "../style.css"
 | timeHoursFormat     | [_**TimeHoursFormat**_](#private-types) | false    | 24-hours                         | Sets the time format                                                                  |
 | hideMarketStatus    | boolean                                 | false    | false                            | Shows market status or not                                                            |
 | hideDateRanges      | boolean                                 | false    | false                            | Hides or shows date ranges                                                            |
-| backGroundColor     | string                                  | false    | rgba(19, 23, 34, 0)              | Sets the background color in the widget                                               |
+| backgroundColor     | string                                  | false    | rgba(19, 23, 34, 0)              | Sets the background color in the widget                                               |
 | widgetFontColor     | string                                  | false    | rgba(216, 216, 216, 1)           | Sets the font color in the widget                                                     |
 | chartType           | [_**ChartType**_](#public-types)        | false    | area                             | Sets the chart type                                                                   |
 | lineColor           | string                                  | false    | #2962FF                          | Sets the line color, chartType **area** only.                                         |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,10 @@ importers:
   .:
     dependencies:
       react:
-        specifier: ^17.0.2 || ^18.1.0
+        specifier: ^17.0.2 || ^18.1.0 || ^19.0.0
         version: 18.2.0
       react-dom:
-        specifier: ^17.0.2 || ^18.1.0
+        specifier: ^17.0.2 || ^18.1.0 || ^19.0.0
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@babel/cli':

--- a/src/components/SymbolOverview.tsx
+++ b/src/components/SymbolOverview.tsx
@@ -74,7 +74,7 @@ export type SymbolOverviewProps = {
   wickDownColor?: string;
 
   //colors
-  backGroundColor?: string;
+  backgroundColor?: string;
   gridLineColor?: string;
   widgetFontColor?: string;
 
@@ -133,7 +133,7 @@ const SymbolOverview: React.FC<SymbolOverviewProps> = ({
   wickUpColor = "#26a69a",
   wickDownColor = "#ef5350",
 
-  backGroundColor = "rgba(19, 23, 34, 0)",
+  backgroundColor = "rgba(19, 23, 34, 0)",
   gridLineColor = "rgba(42, 46, 57, 0)",
   widgetFontColor = "rgba(216, 216, 216, 1)",
 
@@ -182,7 +182,7 @@ const SymbolOverview: React.FC<SymbolOverviewProps> = ({
           wickUpColor,
           wickDownColor,
         }),
-        backGroundColor,
+        backgroundColor,
         widgetFontColor,
         gridLineColor,
         autosize,


### PR DESCRIPTION
fixed typo in SymbolOverview so "backgroundColor" prop works. 